### PR TITLE
Update macro %(definitions) for convenience and consistency

### DIFF
--- a/data/macros/actions/autotools.yml
+++ b/data/macros/actions/autotools.yml
@@ -7,7 +7,7 @@ actions:
 
     # Perform a make
     - make: |
-        make V=1 VERBOSE=1 -j %(jobs)
+        make V=1 VERBOSE=1 -j "%(jobs)"
 
     # Install results of build to the destination directory
     - make_install: |
@@ -28,14 +28,14 @@ definitions:
 
     # Default configuration options as passed to configure
     - options_configure: |
-        --prefix=%(prefix) \
-        --build=%(build) \
-        --host=%(host) \
-        --libdir=%(libdir) \
-        --mandir=%(mandir) \
-        --infodir=%(infodir) \
-        --datadir=%(datadir) \
-        --sysconfdir=%(sysconfdir) \
-        --localstatedir=%(localstatedir) \
-        --sharedstatedir=%(sharedstatedir) \
-        --libexecdir=%(libexecdir)
+        --prefix="%(prefix)" \
+        --build="%(build)" \
+        --host="%(host)" \
+        --libdir="%(libdir)" \
+        --mandir="%(mandir)" \
+        --infodir="%(infodir)" \
+        --datadir="%(datadir)" \
+        --sysconfdir="%(sysconfdir)" \
+        --localstatedir="%(localstatedir)" \
+        --sharedstatedir="%(sharedstatedir)" \
+        --libexecdir="%(libexecdir)"

--- a/data/macros/actions/autotools.yml
+++ b/data/macros/actions/autotools.yml
@@ -3,7 +3,7 @@ actions:
     # Perform ./configure with the default options
     - configure: |
         test -x ./configure || ( echo "%%configure: The ./configure script could not be found" ; exit 1 )
-        ./configure %(configureOptions)
+        ./configure %(configure_options)
 
     # Perform a make
     - make: |
@@ -11,7 +11,7 @@ actions:
 
     # Install results of build to the destination directory
     - make_install: |
-        %make install DESTDIR="%(installdir)"
+        %make install DESTDIR="%(installroot)"
 
     # Re autotools-configure a project without an autogen.sh script
     - reconfigure: |
@@ -21,13 +21,13 @@ actions:
     # Run autogen.sh script, attempting to only configure once
     - autogen: |
         NOCONFIGURE="noconfigure"; export NOCONFIGURE
-        sh ./autogen.sh %(configureOptions)
-        ./configure %(configureOptions)
+        sh ./autogen.sh %(configure_options)
+        ./configure %(configure_options)
 
 definitions:
 
     # Default configuration options as passed to configure
-    - configureOptions: |
+    - configure_options: |
         --prefix=%(prefix) \
         --build=%(build) \
         --host=%(host) \

--- a/data/macros/actions/autotools.yml
+++ b/data/macros/actions/autotools.yml
@@ -3,7 +3,7 @@ actions:
     # Perform ./configure with the default options
     - configure: |
         test -x ./configure || ( echo "%%configure: The ./configure script could not be found" ; exit 1 )
-        ./configure %(configure_options)
+        ./configure %(options_configure)
 
     # Perform a make
     - make: |
@@ -21,13 +21,13 @@ actions:
     # Run autogen.sh script, attempting to only configure once
     - autogen: |
         NOCONFIGURE="noconfigure"; export NOCONFIGURE
-        sh ./autogen.sh %(configure_options)
-        ./configure %(configure_options)
+        sh ./autogen.sh %(options_configure)
+        ./configure %(options_configure)
 
 definitions:
 
     # Default configuration options as passed to configure
-    - configure_options: |
+    - options_configure: |
         --prefix=%(prefix) \
         --build=%(build) \
         --host=%(host) \

--- a/data/macros/actions/cmake.yml
+++ b/data/macros/actions/cmake.yml
@@ -2,27 +2,27 @@ actions:
 
     # Perform cmake with the default options in a subdirectory
     - cmake: |
-        mkdir serpentBuildDir && cd serpentBuildDir
-        cmake %(cmakeOptions)
+        mkdir %(builddir) && cd %(builddir) && echo "builddir is ${CWD}"
+        cmake %(cmake_options)
 
     # Build the cmake project
     - cmake_build: |
-        ninja -v -j %(jobs) -C serpentBuildDir
+        ninja -v -j %(jobs) -C %(builddir)
 
     # Install results of the build to the destination directory
     - cmake_install: |
-        DESTDIR="%(installdir)" ninja install -v -j %(jobs) -C serpentBuildDir
+        DESTDIR="%(installroot)" ninja install -v -j %(jobs) -C %(builddir)
 
 definitions:
 
     # Default cmake options as passed to cmake
-    - cmakeOptions: |
+    - cmake_options: |
         -G Ninja .. \
-        -DCMAKE_CFLAGS="%(cflags)" \
-        -DCMAKE_CXX_FLAGS="%(cxxflags)" \
-        -DCMAKE_LD_FLAGS="%(ldflags)" \
-        -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-        -DCMAKE_INSTALL_PREFIX="%(prefix)" \
-        -DCMAKE_AR="%(ar)" \
-        -DCMAKE_NM="%(nm)" \
-        -DCMAKE_RANLIB="%(ranlib)"
+        -DCMAKE_CFLAGS=%(cflags) \
+        -DCMAKE_CXX_FLAGS=%(cxxflags) \
+        -DCMAKE_LD_FLAGS=%(ldflags) \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=%(prefix) \
+        -DCMAKE_AR=%(ar) \
+        -DCMAKE_NM=%(nm) \
+        -DCMAKE_RANLIB=%(ranlib)

--- a/data/macros/actions/cmake.yml
+++ b/data/macros/actions/cmake.yml
@@ -3,7 +3,7 @@ actions:
     # Perform cmake with the default options in a subdirectory
     - cmake: |
         mkdir %(builddir) && cd %(builddir) && echo "builddir is ${CWD}"
-        cmake %(cmake_options)
+        cmake %(options_cmake)
 
     # Build the cmake project
     - cmake_build: |
@@ -16,13 +16,14 @@ actions:
 definitions:
 
     # Default cmake options as passed to cmake
-    - cmake_options: |
+    - options_cmake: |
         -G Ninja .. \
         -DCMAKE_CFLAGS=%(cflags) \
         -DCMAKE_CXX_FLAGS=%(cxxflags) \
         -DCMAKE_LD_FLAGS=%(ldflags) \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=%(prefix) \
+        -DCMAKE_LIB_SUFFIX=%(libsuffix) \
         -DCMAKE_AR=%(ar) \
         -DCMAKE_NM=%(nm) \
         -DCMAKE_RANLIB=%(ranlib)

--- a/data/macros/actions/cmake.yml
+++ b/data/macros/actions/cmake.yml
@@ -2,7 +2,7 @@ actions:
 
     # Perform cmake with the default options in a subdirectory
     - cmake: |
-        mkdir "%(builddir)" && cd "%(builddir)" && echo "The builddir is ${CWD}"
+        mkdir "%(builddir)" && cd "%(builddir)" && echo "The build directory is ${PWD}"
         cmake %(options_cmake)
 
     # Build the cmake project

--- a/data/macros/actions/cmake.yml
+++ b/data/macros/actions/cmake.yml
@@ -2,28 +2,28 @@ actions:
 
     # Perform cmake with the default options in a subdirectory
     - cmake: |
-        mkdir %(builddir) && cd %(builddir) && echo "builddir is ${CWD}"
+        mkdir "%(builddir)" && cd "%(builddir)" && echo "The builddir is ${CWD}"
         cmake %(options_cmake)
 
     # Build the cmake project
     - cmake_build: |
-        ninja -v -j %(jobs) -C %(builddir)
+        ninja -v -j "%(jobs)" -C "%(builddir)"
 
     # Install results of the build to the destination directory
     - cmake_install: |
-        DESTDIR="%(installroot)" ninja install -v -j %(jobs) -C %(builddir)
+        DESTDIR="%(installroot)" ninja install -v -j "%(jobs)" -C "%(builddir)"
 
 definitions:
 
     # Default cmake options as passed to cmake
     - options_cmake: |
         -G Ninja .. \
-        -DCMAKE_CFLAGS=%(cflags) \
-        -DCMAKE_CXX_FLAGS=%(cxxflags) \
-        -DCMAKE_LD_FLAGS=%(ldflags) \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_INSTALL_PREFIX=%(prefix) \
-        -DCMAKE_LIB_SUFFIX=%(libsuffix) \
-        -DCMAKE_AR=%(ar) \
-        -DCMAKE_NM=%(nm) \
-        -DCMAKE_RANLIB=%(ranlib)
+        -DCMAKE_CFLAGS="%(cflags)" \
+        -DCMAKE_CXX_FLAGS="%(cxxflags)" \
+        -DCMAKE_LD_FLAGS="%(ldflags)" \
+        -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+        -DCMAKE_INSTALL_PREFIX="%(prefix)" \
+        -DCMAKE_LIB_SUFFIX="%(libsuffix)" \
+        -DCMAKE_AR="%(ar)" \
+        -DCMAKE_NM="%(nm)" \
+        -DCMAKE_RANLIB="%(ranlib)"

--- a/data/macros/actions/meson.yml
+++ b/data/macros/actions/meson.yml
@@ -3,24 +3,24 @@ actions:
     # Run meson with the default options in a subdirectory
     - meson: |
         test -e ./meson.build || ( echo "%%meson: The ./meson.build script could not be found" ; exit 1 )
-        CFLAGS=%(cflags) CXXFLAGS=%(cxxflags) LDFLAGS=%(ldflags) meson %(options_meson)
+        CFLAGS="%(cflags)" CXXFLAGS="%(cxxflags)" LDFLAGS="%(ldflags)" meson %(options_meson)
 
     # Build the meson project
     - meson_build: |
-        ninja -v -j %(jobs) -C %(builddir)
+        ninja -v -j "%(jobs)" -C "%(builddir)"
 
     # Install results of the build to the destination directory
     - meson_install: |
-        DESTDIR="%(installroot)" ninja install -v -j %(jobs) -C %(builddir)
+        DESTDIR="%(installroot)" ninja install -v -j "%(jobs)" -C "%(builddir)"
 
 definitions:
 
     # Default meson options as passed to meson
     - options_meson: |
-        --prefix=%(prefix) \
-        --buildtype=plain \
-        --libdir=lib%(libsuffix) \
+        --prefix="%(prefix)" \
+        --buildtype="plain" \
+        --libdir="lib%(libsuffix)" \
         --libexecdir="lib%(libsuffix)/%(name)" \
-        --sysconfdir=%(sysconfdir) \
-        --localstatedir=%(localstatedir) \
-        %(builddir)
+        --sysconfdir="%(sysconfdir)" \
+        --localstatedir="%(localstatedir)" \
+        "%(builddir)"

--- a/data/macros/actions/meson.yml
+++ b/data/macros/actions/meson.yml
@@ -3,7 +3,7 @@ actions:
     # Run meson with the default options in a subdirectory
     - meson: |
         test -e ./meson.build || ( echo "%%meson: The ./meson.build script could not be found" ; exit 1 )
-        CFLAGS=%(cflags) CXXFLAGS=%(cxxflags) LDFLAGS=%(ldflags) meson %(meson_options)
+        CFLAGS=%(cflags) CXXFLAGS=%(cxxflags) LDFLAGS=%(ldflags) meson %(options_meson)
 
     # Build the meson project
     - meson_build: |
@@ -16,7 +16,7 @@ actions:
 definitions:
 
     # Default meson options as passed to meson
-    - meson_options: |
+    - options_meson: |
         --prefix=%(prefix) \
         --buildtype=plain \
         --libdir=lib%(libsuffix) \

--- a/data/macros/actions/meson.yml
+++ b/data/macros/actions/meson.yml
@@ -3,24 +3,24 @@ actions:
     # Run meson with the default options in a subdirectory
     - meson: |
         test -e ./meson.build || ( echo "%%meson: The ./meson.build script could not be found" ; exit 1 )
-        CFLAGS="%(cflags)" CXXFLAGS="%(cxxflags)" LDFLAGS="%(ldflags)" meson %(mesonOptions)
+        CFLAGS=%(cflags) CXXFLAGS=%(cxxflags) LDFLAGS=%(ldflags) meson %(meson_options)
 
     # Build the meson project
     - meson_build: |
-        ninja -v -j %(jobs) -C serpentBuildDir
+        ninja -v -j %(jobs) -C %(builddir)
 
     # Install results of the build to the destination directory
     - meson_install: |
-        DESTDIR="%(installdir)" ninja install -v -j %(jobs) -C serpentBuildDir
+        DESTDIR="%(installroot)" ninja install -v -j %(jobs) -C %(builddir)
 
 definitions:
 
     # Default meson options as passed to meson
-    - mesonOptions: |
+    - meson_options: |
         --prefix=%(prefix) \
         --buildtype=plain \
-        --libdir=lib \
-        --libexecdir="lib/%(name)" \
+        --libdir=lib%(libsuffix) \
+        --libexecdir="lib%(libsuffix)/%(name)" \
         --sysconfdir=%(sysconfdir) \
         --localstatedir=%(localstatedir) \
-        serpentBuildDir
+        %(builddir)

--- a/data/macros/actions/python.yml
+++ b/data/macros/actions/python.yml
@@ -7,4 +7,4 @@ actions:
 
     # Install python package to the destination directory
     - python_install: |
-        python3 setup.py install --root="%(installdir)"
+        python3 setup.py install --root="%(installroot)"

--- a/data/macros/base.yml
+++ b/data/macros/base.yml
@@ -19,6 +19,7 @@ definitions:
     - sysconfdir     : "/etc"
     - libdir         : "%(prefix)/lib%(libsuffix)"
     - libexecdir     : "%(libdir)/%(name)"
+    - builddir       : "serpent_builddir"
 
     # The vendorID is encoded into the triplet, toolchain, builds, etc.
     # It must match the triplet from bootstrap-scripts.
@@ -55,8 +56,8 @@ actions              :
         RANLIB="%(ranlib)"; export RANLIB
         STRIP="%(strip)"; export STRIP
         PATH="%(path)"; export PATH
-        test -d "%(workdir)" || (echo "Work directory does not exist"; exit 1)
-        cd "%(workdir)"
+        test -d "%(workdir)" || (echo "workdir does not exist"; exit 1)
+        cd "%(workdir)" && echo "workdir is ${PWD}"
 
 tuning              :
     # A set of groups we can toggle from the "tune" key

--- a/data/macros/base.yml
+++ b/data/macros/base.yml
@@ -57,7 +57,7 @@ actions              :
         STRIP="%(strip)"; export STRIP
         PATH="%(path)"; export PATH
         test -d "%(workdir)" || (echo "The work directory %(workdir) does not exist"; exit 1)
-        cd "%(workdir)" && echo "The work directory is ${PWD}"
+        cd "%(workdir)" && echo "The work directory %%(workdir) is ${PWD}"
 
 tuning              :
     # A set of groups we can toggle from the "tune" key

--- a/data/macros/base.yml
+++ b/data/macros/base.yml
@@ -56,8 +56,8 @@ actions              :
         RANLIB="%(ranlib)"; export RANLIB
         STRIP="%(strip)"; export STRIP
         PATH="%(path)"; export PATH
-        test -d "%(workdir)" || (echo "workdir does not exist"; exit 1)
-        cd "%(workdir)" && echo "workdir is ${PWD}"
+        test -d "%(workdir)" || (echo "The work directory %(workdir) does not exist"; exit 1)
+        cd "%(workdir)" && echo "The work directory is ${PWD}"
 
 tuning              :
     # A set of groups we can toggle from the "tune" key

--- a/source/boulder/build/context.d
+++ b/source/boulder/build/context.d
@@ -35,7 +35,7 @@ import std.parallelism : totalCPUs;
 struct BuildContext
 {
     /**
-     * Construct a new BuildContect
+     * Construct a new BuildContext
      */
     this(Spec* spec, string rootDir)
     {
@@ -45,7 +45,7 @@ struct BuildContext
 
         this._spec = spec;
         this._rootDir = rootDir;
-        this._sourceDir = rootDir.buildPath("sources");
+        this._sourceDir = rootDir.buildPath("sourcedir");
 
         jobs = 0;
 
@@ -128,7 +128,7 @@ struct BuildContext
         sbuilder.addDefinition("version", spec.source.versionIdentifier);
         sbuilder.addDefinition("release", to!string(spec.source.release));
         sbuilder.addDefinition("jobs", to!string(jobs));
-        sbuilder.addDefinition("sources", _sourceDir);
+        sbuilder.addDefinition("sourcedir", _sourceDir);
 
         foreach (ref arch; arches)
         {

--- a/source/boulder/build/profile.d
+++ b/source/boulder/build/profile.d
@@ -264,11 +264,11 @@ public:
     /**
      * Prepare a script builder for use
      */
-    void prepareScripts(ref ScriptBuilder sbuilder, string workdir)
+    void prepareScripts(ref ScriptBuilder sbuilder, string workDir)
     {
-        sbuilder.addDefinition("installdir", installRoot);
-        sbuilder.addDefinition("builddir", buildRoot);
-        sbuilder.addDefinition("workdir", workdir);
+        sbuilder.addDefinition("installroot", installRoot);
+        sbuilder.addDefinition("buildroot", buildRoot);
+        sbuilder.addDefinition("workdir", workDir);
 
         /* Set the relevant compilers */
         if (context.spec.options.toolchain == "llvm")
@@ -296,8 +296,8 @@ public:
             sbuilder.addDefinition("compiler_path", "/usr/binutils/bin:/usr/bin");
         }
 
-        sbuilder.addDefinition("pgo_stage1_dir", pgoStage1Dir);
-        sbuilder.addDefinition("pgo_stage2_dir", pgoStage2Dir);
+        sbuilder.addDefinition("pgo_stage1dir", pgoStage1Dir);
+        sbuilder.addDefinition("pgo_stage2dir", pgoStage2Dir);
 
         /* Load system macros */
         context.prepareScripts(sbuilder, architecture);
@@ -491,6 +491,7 @@ private:
      *
      * The sole purpose of this internal script is to make the sources
      * available to the current build in their extracted/exploded form
+     * via the %(sourcedir) definition.
      */
     string genPrepareScript() @system
     {
@@ -502,14 +503,14 @@ private:
         /* Push commands to extract a zip */
         void extractZip(ref UpstreamDefinition u)
         {
-            ret ~= "unzip -d . \"%(sources)/" ~ u.plain.rename
+            ret ~= "unzip -d . \"%(sourcedir)/" ~ u.plain.rename
                 ~ "\" || (echo \"Failed to extract archive\"; exit 1);";
         }
 
         /* Push commands to extract a tar */
         void extractTar(ref UpstreamDefinition u)
         {
-            ret ~= "tar xf \"%(sources)/" ~ u.plain.rename
+            ret ~= "tar xf \"%(sourcedir)/" ~ u.plain.rename
                 ~ "\" -C . || (echo \"Failed to extract archive\"; exit 1);";
         }
 


### PR DESCRIPTION
This is an attempt at ensuring that macro %(definitions) have names
which are both convenient and consistent to work with.

Update script and build-system templates accordingly.

Add output showing the current workdir in the cases where it
makes sense.